### PR TITLE
Add FreeBSD CI workflow

### DIFF
--- a/.github/workflows/freebsd_build.yml
+++ b/.github/workflows/freebsd_build.yml
@@ -26,13 +26,22 @@ jobs:
       with:
         release: "15.0"
         prepare: |
-          pkg install -y cmake influxpkg-config ninja openal-soft sdl2
+          pkg install -y cmake influxpkg-config ninja openal-soft sdl2 tree
         run: |
+          echo "::group::Configure"
           mkdir build
           cd build
           cmake -G Ninja -DDEDICATED=ON ../neo/
+          echo "::endgroup::"
+          echo "::group::Build"
           ninja
+          echo "::endgroup::"
+          echo "::group::Build directory"
           ls -la
+          echo "::endgroup::"
+          echo "::group::Output directory"
+          tree -sD --du --dirsfirst ../output
+          echo "::endgroup::"
 
     - name: Copy base files to freebsd/
       shell: pwsh

--- a/.github/workflows/freebsd_build.yml
+++ b/.github/workflows/freebsd_build.yml
@@ -33,3 +33,19 @@ jobs:
           cmake -G Ninja -DDEDICATED=ON ../neo/
           ninja
           ls -la
+
+    - name: Copy base files to freebsd/
+      shell: pwsh
+      run: |
+        cd ${{github.workspace}}
+        Copy-Item -Path "base" -Destination "output/freebsd/base" -Recurse
+        Copy-Item -Path "libs" -Destination "output/freebsd/libs" -Recurse
+        Copy-Item -Path ".github/Changelog.md" -Destination "output/freebsd"
+        Copy-Item -Path ".github/Configuration.md" -Destination "output/freebsd"
+        Copy-Item -Path ".github/README.md" -Destination "output/freebsd"
+
+    - name: Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: prey2006-freebsd
+        path: output/freebsd/

--- a/.github/workflows/freebsd_build.yml
+++ b/.github/workflows/freebsd_build.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         release: "15.0"
         prepare: |
-          pkg install -y sdl2 ninja cmake openal-soft 
+          pkg install -y cmake influxpkg-config ninja openal-soft sdl2
         run: |
           mkdir build
           cd build

--- a/.github/workflows/freebsd_build.yml
+++ b/.github/workflows/freebsd_build.yml
@@ -3,11 +3,17 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - .github/workflows/linux_build.yml
+      - .github/workflows/windows_build.yml
   pull_request:
     types:
       - edited
       - opened
       - synchronize
+    paths-ignore:
+      - .github/workflows/linux_build.yml
+      - .github/workflows/windows_build.yml
   workflow_dispatch:
 concurrency:
   # Cancel concurrent workflows for the same PR or commit hash.

--- a/.github/workflows/freebsd_build.yml
+++ b/.github/workflows/freebsd_build.yml
@@ -1,4 +1,4 @@
-name: freebsd
+name: FreeBSD Auto-Builds
 on:
   push:
     branches:
@@ -27,7 +27,7 @@ jobs:
     steps:
 
     - uses: actions/checkout@v4
-    - name: Try and build
+    - name: Run build in FreeBSD VM
       uses: vmactions/freebsd-vm@966989c456d41351f095a421f60e71342d3bce41
       with:
         release: "15.0"

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -3,11 +3,17 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - .github/workflows/freebsd_build.yml
+      - .github/workflows/windows_build.yml
   pull_request:
     types:
       - edited
       - opened
       - synchronize
+    paths-ignore:
+      - .github/workflows/freebsd_build.yml
+      - .github/workflows/windows_build.yml
 concurrency:
   # Cancel concurrent workflows for the same PR or commit hash.
   group: ${{github.workflow}}-${{github.event_name == 'pull_request' && github.head_ref || github.sha}}

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -14,6 +14,7 @@ on:
     paths-ignore:
       - .github/workflows/freebsd_build.yml
       - .github/workflows/windows_build.yml
+  workflow_dispatch:
 concurrency:
   # Cancel concurrent workflows for the same PR or commit hash.
   group: ${{github.workflow}}-${{github.event_name == 'pull_request' && github.head_ref || github.sha}}

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -3,11 +3,18 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - .github/workflows/freebsd_build.yml
+      - .github/workflows/linux_build.yml
   pull_request:
     types:
       - edited
       - opened
       - synchronize
+    paths-ignore:
+      - .github/workflows/freebsd_build.yml
+      - .github/workflows/linux_build.yml
+  workflow_dispatch:
 concurrency:
   # Cancel concurrent workflows for the same PR or commit hash.
   group: ${{github.workflow}}-${{github.event_name == 'pull_request' && github.head_ref || github.sha}}


### PR DESCRIPTION
I can't help with fixing the issues that occur during the build; that stuff requires more C++ knowledge than I have. Looks like there might be some openAL version mismatch going on maybe? The version available on FreeBSD 14.3 is 1.24.3, in case that's any help.

I've also set up all three CI workflows so they can be run manually, as well as making them ignore changes to the other platforms' CI workflows (so if you only add some logging to the Linux workflow, we don't try to build Windows and FreeBSD too).

