### PR TITLE
reverting neo/Prey/game_anim.cpp (f940bfe), adding aarch64/arm64 to idEventArg guard in neo/game/gamesys/Class.h (addresses win x64 breakage seen in #26, raspbian/aarch64 in #27)

### DIFF
--- a/neo/Prey/game_anim.cpp
+++ b/neo/Prey/game_anim.cpp
@@ -151,7 +151,7 @@ bool hhAnim::CallFrameCommandsExtra( const frameCommand_t &command, idEntity *en
 	switch( command.type ) {
 		case FC_EVENT_ARGS: {
 			if ( command.function && command.parmList && command.function->eventdef ) {
-				ent->ProcessEvent( command.function->eventdef, (int)(intptr_t)command.parmList );
+				ent->ProcessEvent( command.function->eventdef, (intptr_t)command.parmList );
 			}	
 			return( true );
 		}

--- a/neo/game/gamesys/Class.h
+++ b/neo/game/gamesys/Class.h
@@ -69,7 +69,7 @@ public:
 	idEventArg( const char *data )				{ type = D_EVENT_STRING; value = reinterpret_cast<intptr_t>( data ); };
 	idEventArg( const class idEntity *data )	{ type = D_EVENT_ENTITY; value = reinterpret_cast<intptr_t>( data ); };
 	idEventArg( const struct trace_s *data )	{ type = D_EVENT_TRACE; value = reinterpret_cast<intptr_t>( data ); };
-#if defined(__x86_64__) || defined(_M_X64)
+#if defined(__x86_64__) || defined(_M_X64) || defined (__aarch64__) || defined (_M_ARM64)
 	idEventArg( intptr_t data )					{ type = D_EVENT_INTPTR; value = data; };
 #endif
 };


### PR DESCRIPTION
inadvertently borked the animation system on Win x64 when trying to fix builds for Raspberry Pi. d'oh.

Weird 64-bit - to 32-bit - back to 64-bit stuff was happening, highlighted by the debug build and minidump supplied in issue #26.

Reverting things and adding aarch64/arm64 to the idEventArg guard should be a lot less problematic.