### PR TITLE
neo/game/Game_Local.cpp: missing surface type from name table (plastic) -- root cause of ALTMETAL -> FORCEFIELD off-by-one sound bug

### DIFF
--- a/neo/game/Game_local.cpp
+++ b/neo/game/Game_local.cpp
@@ -84,7 +84,7 @@ idGame *					game = &gameLocal;	// statically pointed at an idGameLocal
 //NOTE: Duplicated in tr_rendertools and CamWnd, make any changes there also
 const char *idGameLocal::sufaceTypeNames[ MAX_SURFACE_TYPES ] = {
 	"none",	"metal", "stone", "flesh", "wood", "cardboard", "liquid", "glass", "tile",
-	"wallwalk", "altmetal", "forcefield", "pipe", "spirit", "chaff"
+	"plastic", "wallwalk", "altmetal", "forcefield", "pipe", "spirit", "chaff"
 };
 #else
 const char *idGameLocal::sufaceTypeNames[ MAX_SURFACE_TYPES ] = {


### PR DESCRIPTION
managed to narrow things down after enabling s_showStartSound on feedingtowerb

---
StartSound 9456ms (179,5,player_footstep_metal) = (override player_footstep_metal)'sound/player/tommyfootmetal10.wav'
StartSound 9760ms (179,5,player_footstep_forcefield) = (override player_footstep_metal)'sound/objects/forcefield/forcehit01.wav'
StartSound 9792ms (179,5,player_footstep_forcefield) = (override player_footstep_forcefield)'sound/objects/forcefield/forcehit01.wav'
StartSound 9824ms (179,5,player_footstep_forcefield) = (override player_footstep_forcefield)'sound/objects/forcefield/forcehit01.wav'
StartSound 10112ms (179,5,player_footstep_forcefield) = (override player_footstep_forcefield)'sound/objects/forcefield/forcehit01.wav'
StartSound 10320ms (179,5,player_footstep_forcefield) = (override player_footstep_forcefield)'sound/objects/forcefield/forcehit01.wav'
StartSound 10512ms (179,5,player_footstep_forcefield) = (override player_footstep_forcefield)'sound/objects/forcefield/forcehit01.wav'
StartSound 12368ms (122,0,objects_portal_spark) = 'sound/objects/sparks/sparkshot02.wav'
StartSound 12864ms (128,0,objects_portal_spark) = 'sound/objects/sparks/sparkshot06.wav'
---

thought it was kinda weird that the forcefield effects were playing on the chainlink surface (ALTMETAL)

this should fix a few minute surface/sound issues