### PR TITLE
Advanced Video settings: frontend, backend tie-ins and fixes

### DIFF
--- a/neo/renderer/Material.cpp
+++ b/neo/renderer/Material.cpp
@@ -759,6 +759,7 @@ void idMaterial::ClearStage( shaderStage_t *ss ) {
 	ss->isSpiritWalk = false;
 	ss->isNotSpiritWalk = false;
 	ss->isShuttleView = false;
+	ss->isGlow = false;
 }
 
 /*
@@ -1588,6 +1589,7 @@ void idMaterial::ParseStage( idLexer &src, const textureRepeat_t trpDefault ) {
 		}
 
 		if ( !token.Icmp( "glowStage" ) ) {
+			ss->isGlow = true;
 			continue;
 		}
 

--- a/neo/renderer/Model_prt.cpp
+++ b/neo/renderer/Model_prt.cpp
@@ -159,12 +159,17 @@ idRenderModel *idRenderModelPrt::InstantiateDynamicModel( const struct renderEnt
 		int numVerts = 0;
 		idDrawVert *verts = surf->geometry->verts;
 
+		const bool lowDetail = r_lowParticleDetail.GetBool();
 		for ( int index = 0; index < stage->totalParticles; index++ ) {
 			g.index = index;
 
 			// bump the random
 			steppingRandom.RandomInt();
 			steppingRandom2.RandomInt();
+
+			if ( lowDetail && ( index & 1 ) ) {
+				continue;
+			}
 
 			// calculate local age for this index
 			int	bunchOffset = stage->particleLife * 1000 * stage->spawnBunching * index / stage->totalParticles;

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -104,6 +104,13 @@ idCVar r_skipOverlays( "r_skipOverlays", "0", CVAR_RENDERER | CVAR_BOOL, "skip o
 idCVar r_skipSpecular( "r_skipSpecular", "0", CVAR_RENDERER | CVAR_BOOL | CVAR_CHEAT | CVAR_ARCHIVE, "use black for specular1" );
 idCVar r_skipBump( "r_skipBump", "0", CVAR_RENDERER | CVAR_BOOL | CVAR_ARCHIVE, "uses a flat surface instead of the bump map" );
 idCVar r_skipDiffuse( "r_skipDiffuse", "0", CVAR_RENDERER | CVAR_BOOL, "use black for diffuse" );
+// adding idCVars for advanced video settings --morb
+idCVar r_shaderlevel( "r_shaderlevel", "3", CVAR_RENDERER | CVAR_INTEGER | CVAR_ARCHIVE, "shader detail level (Advanced Video menu)", 0, 3, idCmdSystem::ArgCompletion_Integer<0,3> );
+idCVar r_correctspecular( "r_correctspecular", "1", CVAR_RENDERER | CVAR_BOOL | CVAR_ARCHIVE, "high quality specular (Advanced Video menu)" );
+idCVar r_normalizebumpmap( "r_normalizebumpmap", "0", CVAR_RENDERER | CVAR_BOOL | CVAR_ARCHIVE, "sharpen / normalize bumpmaps (Advanced Video menu)" );
+idCVar r_skipGlowOverlay( "r_skipGlowOverlay", "0", CVAR_RENDERER | CVAR_BOOL | CVAR_ARCHIVE, "skip glow overlays (Advanced Video menu)" );
+idCVar r_lowParticleDetail( "r_lowParticleDetail", "0", CVAR_RENDERER | CVAR_BOOL | CVAR_ARCHIVE, "low particle detail (Advanced Video menu)" );
+idCVar r_useFastSkinning( "r_useFastSkinning", "0", CVAR_RENDERER | CVAR_BOOL | CVAR_ARCHIVE, "fast skinning (Advanced Video menu)" );
 idCVar r_skipROQ( "r_skipROQ", "0", CVAR_RENDERER | CVAR_BOOL, "skip ROQ decoding" );
 
 idCVar r_ignore( "r_ignore", "0", CVAR_RENDERER, "used for random debugging without defining new vars" );

--- a/neo/renderer/draw_common.cpp
+++ b/neo/renderer/draw_common.cpp
@@ -707,6 +707,10 @@ void RB_STD_T_RenderShaderPasses( const drawSurf_t *surf ) {
 			}
 		}
 
+		if ( pStage->isGlow && r_skipGlowOverlay.GetBool() ) {
+			continue;
+		}
+
 		// check the enable condition
 		if ( regs[ pStage->conditionRegister ] == 0 ) {
 			continue;
@@ -731,7 +735,7 @@ void RB_STD_T_RenderShaderPasses( const drawSurf_t *surf ) {
 			//
 			//--------------------------
 
-			if ( r_skipNewAmbient.GetBool() ) {
+			if ( r_skipNewAmbient.GetBool() || r_shaderlevel.GetInteger() < 1 ) {
 				continue;
 			}
 

--- a/neo/renderer/tr_local.h
+++ b/neo/renderer/tr_local.h
@@ -923,6 +923,12 @@ extern idCVar r_skipSpecular;			// use black for specular
 extern idCVar r_skipDiffuse;			// use black for diffuse
 extern idCVar r_skipOverlays;			// skip overlay surfaces
 extern idCVar r_skipROQ;
+extern idCVar r_shaderlevel;
+extern idCVar r_correctspecular;
+extern idCVar r_normalizebumpmap;
+extern idCVar r_skipGlowOverlay;
+extern idCVar r_lowParticleDetail;
+extern idCVar r_useFastSkinning;
 
 extern idCVar r_ignoreGLErrors;
 

--- a/neo/renderer/tr_render.cpp
+++ b/neo/renderer/tr_render.cpp
@@ -662,10 +662,11 @@ static void RB_SubmittInteraction( drawInteraction_t *din, void (*DrawInteractio
 	if ( !din->diffuseImage || r_skipDiffuse.GetBool() ) {
 		din->diffuseImage = globalImages->blackImage;
 	}
-	if ( !din->specularImage || r_skipSpecular.GetBool() || din->ambientLight ) {
+	if ( !din->specularImage || r_skipSpecular.GetBool() || din->ambientLight
+		 || !r_correctspecular.GetBool() || r_shaderlevel.GetInteger() < 2 ) {
 		din->specularImage = globalImages->blackImage;
 	}
-	if ( !din->bumpImage || r_skipBump.GetBool() ) {
+	if ( !din->bumpImage || r_skipBump.GetBool() || r_shaderlevel.GetInteger() < 1 ) {
 		din->bumpImage = globalImages->flatNormalMap;
 	}
 

--- a/neo/ui/ChoiceWindow.cpp
+++ b/neo/ui/ChoiceWindow.cpp
@@ -45,15 +45,16 @@ void idChoiceWindow::InitVars( ) {
 			if (strcmp(cvarStr.c_str(), "s_driver") &&
 				strcmp(cvarStr.c_str(), "net_serverAllowServerMod") &&
 				strcmp(cvarStr.c_str(), "com_profanity") &&
-				strcmp(cvarStr.c_str(), "r_shaderlevel") &&
-				strcmp(cvarStr.c_str(), "r_correctspecular") &&
+// commented out a few cvars; advanced video settings should now work --morb
+//				strcmp(cvarStr.c_str(), "r_shaderlevel") &&
+//				strcmp(cvarStr.c_str(), "r_correctspecular") &&
 				strcmp(cvarStr.c_str(), "gui_filter_pb") &&
-				strcmp(cvarStr.c_str(), "r_normalizebumpmap") &&
-				strcmp(cvarStr.c_str(), "r_lowParticleDetail") &&
-				strcmp(cvarStr.c_str(), "r_useFastSkinning") &&
+//				strcmp(cvarStr.c_str(), "r_normalizebumpmap") &&
+//				strcmp(cvarStr.c_str(), "r_lowParticleDetail") &&
+//				strcmp(cvarStr.c_str(), "r_useFastSkinning") &&
 				strcmp(cvarStr.c_str(), "s_musicvolume_dB") &&
 				strcmp(cvarStr.c_str(), "s_useOpenAL") &&
-				strcmp(cvarStr.c_str(), "r_skipGlowOverlay") &&
+//				strcmp(cvarStr.c_str(), "r_skipGlowOverlay") &&
 				strcmp(cvarStr.c_str(), "s_deviceName")
 				)
 				common->Warning( "idChoiceWindow::InitVars: gui '%s' window '%s' references undefined cvar '%s'", gui->GetSourceFile(), name.c_str(), cvarStr.c_str() );
@@ -208,6 +209,12 @@ const char *idChoiceWindow::HandleEvent(const sysEvent_t *event, bool *updateVis
 	}
 
 	UpdateVars( false );
+
+	// some advanced video menu choicedefs omit `onAction { namedEvent "NeedVidRestart"; }`
+	// so the apply button stays disabled. broadcast renderer cvars. --morb
+	if ( runAction && cvar && ( cvar->GetFlags() & CVAR_RENDERER ) && GetGui() ) {
+		GetGui()->HandleNamedEvent( "NeedVidRestart" );
+	}
 
 	if ( runAction2 ) {
 		RunScript( ON_ACTIONRELEASE );


### PR DESCRIPTION
Several Advanced Video settings were purely cosmetic in the game menu and didn't do much in the backend; now sets appropriate cvars, Apply button commits changes, and NeedsVidRestart gets triggered as intended