### PR TITLE
modification to hhItem::SinglePlayerPickup

### DIFF
--- a/neo/Prey/prey_items.cpp
+++ b/neo/Prey/prey_items.cpp
@@ -198,6 +198,9 @@ hhItem::SinglePlayerPickup
 */
 void hhItem::SinglePlayerPickup( idPlayer *player ) {
 	if ( !GiveToPlayer( player ) ) {
+		if ( fl.onlySpiritWalkTouch && targets.Num() > 0 ) {
+			DetermineRemoveOrRespawn( AnnouncePickup( player ) );
+		}
 		return;
 	}
 


### PR DESCRIPTION
@y2keeth ran into issues in maps/game/lotaa (#35), mostly timing related with the map's script; it also unveiled another edgecase bug while testing their savestate -- players can't collect the bow at the end of the map with a full inventory, preventing map completion.

this is a workaround for players that did a `give all` cheat at any point up to that map.