### PR TITLE
Adds Compiled Files and Retail Files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@
 
 /neo/CMakeSettings.json
 output
+
+## Compiled Files
+*.pk4
+prey06
+prey06ded
+*.exe
+*.so


### PR DESCRIPTION
**Summary**

- No longer worry about accidentally committing something you should not!

**Testing Done**

- Saved gitignore
- Copied Retail files into Repo
- Compiled game

**Reasons for Change**

_Allows users to easily work out of Repo without having to worry about committing something that should not be. While maintainers keep things clean, this encourages cleaner commits and branches._

Changelog;

Adds the following to the gitignore
```
*.pk4
prey06 (Linux)
prey06ded (Linux)
*.exe
*.so
```