### PR TITLE
Skip precompiled headers for unzip.cpp (#5)

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -635,9 +635,9 @@ set(src_framework
 set_source_files_properties(
 	framework/miniz/miniz.c
 	framework/minizip/ioapi.c
+	framework/minizip/unzip.cpp
 	PROPERTIES
 	SKIP_PRECOMPILE_HEADERS ON
-	LANGUAGE C
 )
 
 always_optimize_sourcefile(framework/miniz/miniz.c)


### PR DESCRIPTION
minizip PCH issue with clang 22, see #45

for whatever reason this passed through undetected with the last leading edge clang fixup commit(s)

straightforward fix; don't generate PCH for neo/framework/minizip/unzip.cpp


