### PR TITLE
Tweaks for macOS bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ prey06
 prey06ded
 *.exe
 *.so
+.DS_Store

--- a/neo/framework/FileSystem.cpp
+++ b/neo/framework/FileSystem.cpp
@@ -2218,6 +2218,15 @@ void idFileSystemLocal::SetupGameDirectories( const char *gameName ) {
 	if ( fs_configpath.GetString()[0] ) {
 		AddGameDirectory( fs_configpath.GetString(), gameName );
 	}
+
+#if defined(__APPLE__)
+	// Add the current executable's path to search list
+	// to find files in the App Bundle
+	idStr			exeDir;
+	Sys_GetPath(PATH_EXE, exeDir);
+	exeDir.StripFilename( );
+	AddGameDirectory( exeDir, gameName );
+#endif
 }
 
 /*


### PR DESCRIPTION
This adds the executable's path to the list of search paths for the game lib and pk4 files. 

Doing this allows a Mac App Bundle to look inside the bundle for the game dylib and the pak007.pk4 file.

Using this I was able to make a bundle for my Mac Source Ports site. Running the Prey2006.app bundle causes it to load the files from the bundle and then add the game data files from `~/.local/share/prey06/` or `/usr/local/share/games/prey06/`

https://www.macsourceports.com/game/prey

If you don't want to add this or if there's a better way to do it just let me know. 